### PR TITLE
Add confirmation before publishing a post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "react-icons": "^5.3.0",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.26.2",
-        "sweetalert2": "^11.14.1"
+        "sweetalert2": "^11.6.13"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/sweetalert2": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.14.1.tgz",
-      "integrity": "sha512-xadhfcA4STGMh8nC5zHFFWURhRpWc4zyI3GdMDFH/m3hGWZeQQNWhX9xcG4lI9gZYsi/IlazKbwvvje3juL3Xg==",
+      "version": "11.6.13",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.6.13.tgz",
+      "integrity": "sha512-n5yVF0FNx1lm4XzpPyb1HIaiptzODfVyeCzmB809tpK+1bPdoKoevKOxYjrtId75DV7xuIp4r6cjn8xUAB8dPQ==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-icons": "^5.3.0",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.26.2",
-    "sweetalert2": "^11.14.1"
+    "sweetalert2": "^11.6.13"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/app/components/UI/Confirm.tsx
+++ b/src/app/components/UI/Confirm.tsx
@@ -2,19 +2,19 @@ import Swal from "sweetalert2"
 
 export const Confirm = async () => {
   const result = await Swal.fire({
-    title: "Are you sure?",
-    text: "You won't be able to revert this!",
+    title: "¿Estas seguro de que desea publicar una nueva entrada?",
+    text: "Esta acción no se puede deshacer.",
     icon: "warning",
     showCancelButton: true,
     confirmButtonColor: "#3085d6",
     cancelButtonColor: "#d33",
-    confirmButtonText: "Yes, delete it!"
+    confirmButtonText: "Publicar"
   })
 
   if (result.isConfirmed) {
     await Swal.fire({
-      title: "Deleted!",
-      text: "Your file has been deleted.",
+      title: "¡Publicada!",
+      text: "Tu entrada ha sido publicada.",
       icon: "success"
     })
   }


### PR DESCRIPTION
Implement a confirmation message before the user publishes a resale post in the 'PublicarReventaComponent'. This will prevent users from accidentally publishing posts without being sure of the action.

This pull request includes the following commits:

- Modify text confirm #15

The changes in the code ensure that a confirmation dialog is displayed to the user before publishing a post. The dialog asks the user if they are sure they want to publish a new post and warns that the action cannot be undone. If the user confirms, the post is published and a success message is displayed.

Fixes #15