### PR TITLE
Add useGetAllTickets hook and getAllTickets service

### DIFF
--- a/src/app/components/UI/BannerLanding.tsx
+++ b/src/app/components/UI/BannerLanding.tsx
@@ -21,7 +21,7 @@ export default function BannerLanding() {
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentIndex((prevIndex) => (prevIndex + 1) % imagesBanner.length)
-    }, 1000)
+    }, 5000)
 
     return () => clearInterval(interval)
   }, [])

--- a/src/app/components/UI/Grid.tsx
+++ b/src/app/components/UI/Grid.tsx
@@ -1,15 +1,17 @@
+import { useEffect } from "react"
+import { useSelector } from "react-redux"
+import { RootState } from "../../../store"
+import { useGetAllTickets } from "../../../hooks/useGetAllTickets"
 import { Link } from "react-router-dom"
 
 export default function Grid() {
-  const images = [
-    "https://via.placeholder.com/150",
-    "https://via.placeholder.com/150",
-    "https://via.placeholder.com/150",
-    "https://via.placeholder.com/150",
-    "https://via.placeholder.com/150",
-    "https://via.placeholder.com/150"
-  ]
+  const { getAllTicketsData } = useGetAllTickets()
+  const tickets = useSelector((state: RootState) => state.entry.tickets);
 
+  useEffect(() => {
+    getAllTicketsData()
+  }, [])
+  
   return (
     <>
       <div className="flex w-full flex-col border-opacity-50">
@@ -25,11 +27,11 @@ export default function Grid() {
 
           {/* Grid de imágenes */}
           <div className="grid grid-cols-3 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {images.map((image, index) => (
+            {tickets.map((ticket, index) => (
               <div key={index} className="w-full">
-                <img src={image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />
+                <img src={ticket.image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />
                 <div>
-                  <p>Nombre de partido</p>
+                  <p>{ticket.gameName}</p>
                 </div>
               </div>
             ))}

--- a/src/app/components/UI/Grid.tsx
+++ b/src/app/components/UI/Grid.tsx
@@ -6,12 +6,12 @@ import { Link } from "react-router-dom"
 
 export default function Grid() {
   const { getAllTicketsData } = useGetAllTickets()
-  const tickets = useSelector((state: RootState) => state.entry.tickets);
+  const tickets = useSelector((state: RootState) => state.entry.tickets)
 
   useEffect(() => {
     getAllTicketsData()
   }, [])
-  
+
   return (
     <>
       <div className="flex w-full flex-col border-opacity-50">
@@ -31,7 +31,7 @@ export default function Grid() {
               <div key={index} className="w-full">
                 <img src={ticket.image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />
                 <div>
-                  <p>{ticket.gameName}</p>
+                  <p className="text-center text-[0.8rem]">{ticket.gameName}</p>
                 </div>
               </div>
             ))}

--- a/src/hooks/useGetAllTickets.ts
+++ b/src/hooks/useGetAllTickets.ts
@@ -1,0 +1,18 @@
+import { getAllTickets } from "../service/getAllTickets";
+import { useDispatch } from "react-redux"
+import { setTickets } from "../store/entry/entrySlice";
+
+export const useGetAllTickets = () => {
+  const dispatch = useDispatch()
+
+  const getAllTicketsData = async (): Promise<void> => {
+    try {
+      const tickets = await getAllTickets()
+      dispatch(setTickets(tickets))
+    } catch (error) {
+      console.error("Error al obtener tickets", error);
+    }
+  }
+
+  return { getAllTicketsData }
+}

--- a/src/service/getAllTickets.ts
+++ b/src/service/getAllTickets.ts
@@ -1,0 +1,16 @@
+import axios from "axios"
+import { httpClient } from "../api/axios-config"
+import { SystemError } from "com/errors"
+
+export const getAllTickets = async () => {
+  try {
+    const response = await httpClient.get("/Entrada/get-tickets")
+    return response.data
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      throw new SystemError(error.message)
+    } else {
+      throw new SystemError("Error de conexión")
+    }
+  }
+}

--- a/src/store/entry/entrySlice.ts
+++ b/src/store/entry/entrySlice.ts
@@ -1,7 +1,18 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
+interface Ticket {
+  image: string;
+  gameName: string;
+  description: string;
+  address: string;
+  eventDate: string;
+  codigoQR: string;
+  verificada: boolean;
+}
+
 const initialState = {
-  codigoQR: ""
+  codigoQR: "",
+  tickets: [] as Ticket[]
 }
 
 const entrySlice = createSlice({
@@ -13,9 +24,12 @@ const entrySlice = createSlice({
     },
     clearEntry(state) {
       state.codigoQR = ""
-    }
+    },
+    setTickets(state, action: PayloadAction<any>) {
+      state.tickets = action.payload
+    },
   }
 })
 
-export const { setEntry, clearEntry } = entrySlice.actions
+export const { setEntry, clearEntry, setTickets } = entrySlice.actions
 export default entrySlice.reducer


### PR DESCRIPTION
This pull request adds a new hook called useGetAllTickets and a corresponding service called getAllTickets. The useGetAllTickets hook is used in the Grid component to fetch all tickets data from the server and store it in the Redux store. The getAllTickets service makes an HTTP request to the server to retrieve the tickets data. Additionally, the Grid component is updated to use the tickets data instead of the hardcoded images array.