### PR TITLE
Fix grid tickets and create API to get sell tickets

### DIFF
--- a/src/app/components/UI/Card.tsx
+++ b/src/app/components/UI/Card.tsx
@@ -1,7 +1,12 @@
 import Button from "../core/Button"
 import { useTranslation } from "react-i18next"
+import { Ticket } from "../../../store/entry/entrySlice"
 
-export default function Card() {
+interface CardProps {
+  ticket: Ticket
+}
+
+export default function Card({ ticket }: CardProps) {
   const { t } = useTranslation()
 
   return (
@@ -9,15 +14,12 @@ export default function Card() {
       <div className="flex justify-center p-2">
         <div className="card w-96 bg-base-100 shadow-2xl">
           <figure>
-            <img
-              src="https://images.unsplash.com/photo-1434648957308-5e6a859697e8?q=80&w=1548&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-              alt="Partido Racing - San Lorenzo"
-            />
+            <img src={ticket.entrada.image} alt="Ticket" />
           </figure>
           <div className="card-body pb-4">
-            <h2 className="card-title text-xl font-bold">RACING - SAN LORENZO</h2>
-            <p className="text-[1.1rem] font-medium">18 Feb - 18:00 EN AVELLANEDA</p>
-            <p className="text-[1.3rem] font-medium">$10</p>
+            <h2 className="card-title text-xl font-bold">{ticket?.entrada.gameName}</h2>
+            <p className="text-[1.1rem] font-medium">{ticket?.entrada.address}</p>
+            <p className="text-[1.3rem] font-medium">{ticket?.entrada.precio}</p>
             <div className="card-actions justify-end">
               <Button className="btn relative -mt-8 bg-customGreen text-2xl text-customWhite hover:bg-customBlack">
                 {t("buy")}

--- a/src/app/components/UI/Grid.tsx
+++ b/src/app/components/UI/Grid.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useSelector } from "react-redux"
 import { RootState } from "../../../store"
-import { useGetAllTickets } from "../../../hooks/useGetAllTickets"
+import { useGetTicketsForSell } from "../../../hooks/useGetTicketsForSell"
 import SearchBar from "./SearchBar"
 import { Ticket } from "../../../store/entry/entrySlice"
 import { useTranslation } from "react-i18next"
@@ -13,7 +13,7 @@ type GridProps = {
 
 export default function Grid({ viewType }: GridProps) {
   const { t } = useTranslation()
-  const { getAllTicketsData } = useGetAllTickets()
+  const { getTicketsForSellData } = useGetTicketsForSell()
   const tickets = useSelector((state: RootState) => state.entry.tickets)
   const [currentPage, setCurrentPage] = useState(1)
   const ticketsPerPage = viewType === "allTickets" ? 15 : 6
@@ -24,11 +24,11 @@ export default function Grid({ viewType }: GridProps) {
   const [searchQuery, setSearchQuery] = useState("")
 
   useEffect(() => {
-    getAllTicketsData(currentPage, ticketsPerPage)
+    getTicketsForSellData(currentPage, ticketsPerPage)
   }, [currentPage, ticketsPerPage])
 
   useEffect(() => {
-    const filtered = tickets.filter((ticket) => ticket.gameName.toLowerCase().includes(searchQuery.toLowerCase()))
+    const filtered = tickets.filter((ticket) => ticket.entrada.gameName.toLowerCase().includes(searchQuery.toLowerCase()))
     setFilteredTickets(filtered)
   }, [tickets, searchQuery])
 
@@ -69,9 +69,9 @@ export default function Grid({ viewType }: GridProps) {
           <div className={`grid grid-cols-3 gap-4`}>
             {filteredTickets.map((ticket, index) => (
               <div key={index} className="w-full cursor-pointer" onClick={() => handleTicketClick(ticket.entradaId)}>
-                <img src={ticket.image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />
+                <img src={ticket?.entrada.image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />
                 <div>
-                  <p className="text-center text-[0.8rem]">{ticket.gameName}</p>
+                  <p className="text-center text-[0.8rem]">{ticket?.entrada.gameName}</p>
                 </div>
               </div>
             ))}

--- a/src/app/views/LatestEntries.tsx
+++ b/src/app/views/LatestEntries.tsx
@@ -1,9 +1,31 @@
-import Card from "../components/UI/Card"
+import { useEffect } from "react"
+import { useSelector } from "react-redux"
+import { RootState } from "../../store"
+import { Ticket } from "../../store/entry/entrySlice"
 
-export default function LatestEntries() {
+import Card from "../components/UI/Card"
+import { useGetTicketsForSell } from "../../hooks/useGetTicketsForSell"
+
+export default function LatestEntries(): JSX.Element {
+  const tickets: Ticket[] = useSelector((state: RootState) => state.entry.tickets)
+  const { getTicketsForSellData } = useGetTicketsForSell()
+  const ticketsPerPage = 3
+  const currentPage = 1
+
+  useEffect(() => {
+    getTicketsForSellData(currentPage, ticketsPerPage)
+  }, [currentPage, ticketsPerPage])
+
+  const sortedTickets = tickets
+    .slice()
+    .sort((a, b) => new Date(b.fechaReventa).getTime() - new Date(a.fechaReventa).getTime())
+    .slice(0, 3)
+
   return (
     <>
-      <Card />
+      {sortedTickets.map((ticket, index) => (
+        <Card key={index} ticket={ticket} />
+      ))}
     </>
   )
 }

--- a/src/hooks/useGetTicketsForSell.ts
+++ b/src/hooks/useGetTicketsForSell.ts
@@ -1,0 +1,25 @@
+import { getTicketsForSell } from "../service/getTicketsForSell"
+import { useDispatch } from "react-redux"
+import { setSellTickets } from "../store/entry/entrySlice"
+import { SystemError } from "com/errors"
+import useContext from "../context/useContext"
+
+export const useGetTicketsForSell = () => {
+  const { alert } = useContext()
+
+  const dispatch = useDispatch()
+
+  const getTicketsForSellData = async (pageNumber: number, pageSize: number): Promise<void> => {
+    try {
+      const data = await getTicketsForSell(pageNumber, pageSize)
+      dispatch(setSellTickets(data))
+    } catch (error: any) {
+      if (error instanceof SystemError) {
+        alert(error.message)
+      }
+      alert(error.message)
+    }
+  }
+
+  return { getTicketsForSellData }
+}

--- a/src/service/getTicketsForSell.ts
+++ b/src/service/getTicketsForSell.ts
@@ -1,0 +1,16 @@
+import axios from "axios"
+import { httpClient } from "../api/axios-config"
+import { SystemError } from "com/errors"
+
+export const getTicketsForSell = async (pageNumber: number, pageSize: number) => {
+  try {
+    const response = await httpClient.get(`/Reventa/get-resales?PageNumber=${pageNumber}&PageSize=${pageSize}`)
+    return response.data
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      throw new SystemError(error.message)
+    } else {
+      throw new SystemError("Error de conexión")
+    }
+  }
+}

--- a/src/store/entry/entrySlice.ts
+++ b/src/store/entry/entrySlice.ts
@@ -9,6 +9,15 @@ export interface Ticket {
   codigoQR: string
   verificada: boolean
   entradaId: number
+  entrada: Entrada
+  fechaReventa: string
+}
+
+export interface Entrada {
+  image: string
+  gameName: string
+  address: string
+  precio: string
 }
 
 const initialState = {
@@ -20,10 +29,17 @@ const initialState = {
     description: "",
     address: "",
     eventDate: "",
-    codigoQR: ""
+    codigoQR: "",
+    verificada: false,
+    entradaId: 0,
+    entrada: {
+      image: "",
+      gameName: "",
+      address: "",
+      precio: ""
+    }
   } as Ticket
 }
-
 const entrySlice = createSlice({
   name: "entry",
   initialState,
@@ -37,9 +53,12 @@ const entrySlice = createSlice({
     },
     setTickets(state, action: PayloadAction<any>) {
       state.tickets = action.payload
+    },
+    setSellTickets(state, action: PayloadAction<any>) {
+      state.tickets = action.payload
     }
   }
 })
 
-export const { setEntry, clearEntry, setTickets } = entrySlice.actions
+export const { setEntry, clearEntry, setTickets, setSellTickets } = entrySlice.actions
 export default entrySlice.reducer


### PR DESCRIPTION
This pull request includes changes to fix the grid tickets functionality and create an API to get sell tickets. The grid component now uses the `useGetTicketsForSell` hook to fetch tickets for selling and display them in the grid. The `Grid` component has been updated to use the `getTicketsForSellData` function from the hook. The `LatestEntries` component now fetches sell tickets using the `getTicketsForSellData` function and displays them using the `Card` component. The `entrySlice` has been updated with a new action `setSellTickets` to set the sell tickets data in the state.