### PR TITLE
Refactor BannerLanding styles and replace CardMyTickets component with MyTicketsCard

### DIFF
--- a/src/app/components/UI/BannerLanding.tsx
+++ b/src/app/components/UI/BannerLanding.tsx
@@ -1,30 +1,21 @@
 import { useEffect, useState } from "react"
-
-const imagesBanner = [
-  "/bannerImg/b1.avif",
-  "/bannerImg/b2.avif",
-  "/bannerImg/b3.avif",
-  "/bannerImg/b4.avif",
-  "/bannerImg/b5.avif",
-  "/bannerImg/b6.avif",
-  "/bannerImg/b7.avif",
-  "/bannerImg/b8.avif",
-  "/bannerImg/b9.avif",
-  "/bannerImg/b10.avif",
-  "/bannerImg/b11.avif",
-  "/bannerImg/b12.avif"
-]
+import { useSelector } from "react-redux"
+import { RootState } from "../../../store"
 
 export default function BannerLanding() {
+  const tickets = useSelector((state: RootState) => state.entry.tickets)
+
+  const imagesBanner = tickets.map((ticket) => ticket.entrada.image)
+
   const [currentIndex, setCurrentIndex] = useState(0)
 
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentIndex((prevIndex) => (prevIndex + 1) % imagesBanner.length)
-    }, 5000)
+    }, 8000)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [imagesBanner.length])
 
   return (
     <div className="flex justify-center">

--- a/src/app/components/UI/BannerLanding.tsx
+++ b/src/app/components/UI/BannerLanding.tsx
@@ -21,8 +21,8 @@ export default function BannerLanding() {
     <div className="flex justify-center">
       <div className="carousel m-3 mt-24 w-full items-center justify-center rounded-md">
         <div className="carousel-item relative w-full">
-          <div className="h-64 w-full md:h-96 lg:h-[500px]">
-            <img src={imagesBanner[currentIndex]} alt="banner" className="h-full w-full rounded-md object-cover" />
+          <div className="h-64 w-full sm:h-80 md:h-96 lg:h-[500px]">
+            <img src={imagesBanner[currentIndex]} alt="banner" className="h-full w-full rounded-md object-contain" />
           </div>
           <div className="absolute left-5 right-5 top-1/2 flex -translate-y-1/2 transform justify-between"></div>
         </div>

--- a/src/app/components/UI/Grid.tsx
+++ b/src/app/components/UI/Grid.tsx
@@ -28,7 +28,9 @@ export default function Grid({ viewType }: GridProps) {
   }, [currentPage, ticketsPerPage])
 
   useEffect(() => {
-    const filtered = tickets.filter((ticket) => ticket.entrada.gameName.toLowerCase().includes(searchQuery.toLowerCase()))
+    const filtered = tickets.filter((ticket) =>
+      ticket.entrada.gameName.toLowerCase().includes(searchQuery.toLowerCase())
+    )
     setFilteredTickets(filtered)
   }, [tickets, searchQuery])
 
@@ -66,7 +68,7 @@ export default function Grid({ viewType }: GridProps) {
           <SearchBar onSearch={handleSearch} />
 
           {/* Grid de imágenes */}
-          <div className={`grid grid-cols-3 gap-4`}>
+          <div className={`grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8`}>
             {filteredTickets.map((ticket, index) => (
               <div key={index} className="w-full cursor-pointer" onClick={() => handleTicketClick(ticket.entradaId)}>
                 <img src={ticket?.entrada.image} alt={`Imagen ${index + 1}`} className="h-auto w-full rounded-md" />

--- a/src/app/components/UI/MyTicketsCard.tsx
+++ b/src/app/components/UI/MyTicketsCard.tsx
@@ -4,7 +4,7 @@ interface CardMyTicketsProps {
   ticket: Ticket
 }
 
-export const CardMyTickets: React.FC<CardMyTicketsProps> = ({ ticket }) => {
+export const MyTicketsCard: React.FC<CardMyTicketsProps> = ({ ticket }) => {
   return (
     <div className="card bg-base-100 p-4 shadow-xl lg:card-side">
       <figure>

--- a/src/app/pages/MyTickets.tsx
+++ b/src/app/pages/MyTickets.tsx
@@ -1,5 +1,5 @@
 import { Navbar } from "../components/UI/Navbar"
-import { CardMyTickets } from "../components/UI/cardMyTickets"
+import { MyTicketsCard } from "../components/UI/MyTicketsCard"
 import { useSelector } from "react-redux"
 import { RootState } from "../../store"
 import { useGetUserTickets } from "../../hooks/useGetUserTickets"
@@ -28,7 +28,7 @@ export const MyTickets: React.FC = () => {
         <ul>
           {tickets.map((ticket: Ticket, index) => (
             <li key={index}>
-              <CardMyTickets ticket={ticket} />
+              <MyTicketsCard ticket={ticket} />
             </li>
           ))}
         </ul>


### PR DESCRIPTION
This pull request includes changes to refactor the styles of the BannerLanding component and replace the CardMyTickets component with the MyTicketsCard component. The styles of the BannerLanding component have been updated to use images from the tickets API. The interval for changing the banner image has been increased to 8 seconds. The Grid component has been updated to display a different number of columns based on the screen size. The CardMyTickets component has been renamed to MyTicketsCard. The MyTickets page now uses the MyTicketsCard component to display the user's tickets.